### PR TITLE
Fix layout issues and overflow 

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2,14 +2,16 @@
   max-width: 1280px;
   margin: 0 auto;
   padding: 2rem;
-  text-align: center;
+  /* text-align: center;  this causes some unusual text issues*/
+
 }
 
-.app {
+.App {
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: 90vw;
+  padding: 0.5em;
+  width: 100%; /*width should be set to the parent container*/
 }
 
 #editor {
@@ -17,12 +19,12 @@
   height: 40vh;
   border-radius: 5px;
   padding: 1rem;
-  margin: 1rem;
+  /* margin: 1rem; */
 
 }
 
 #preview {
-  width: 70vw;
+  width: 100%;/* set to parent container width. vw may allow overflow of the parent*/
 }
 
 #editiorComponent{
@@ -30,11 +32,8 @@
 }
 
 #previewComponent {
-  width: 70vw;
-  display: flex;
-  justify-content: center; /* Horizontal centering */
-  align-items: center; /* Vertical centering */
-
+  width: 90%;
+  /* display: flex;  let default of display:block work on smaller screens*/
 }
 
 .navbar, footer{
@@ -43,3 +42,12 @@
 }
 
 
+@media (min-width:667px) {
+  #previewComponent {
+    /*Just assuming that you want the "Preview" heading next to the preview and not above on larger screens*/
+    display: flex; /*flex should occur on larger breakpoint*/
+    justify-content: center; /* Horizontal centering */
+    align-items: center; /* Vertical centering */
+   
+  }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,8 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
 :root {
   font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
   font-size: 16px;
@@ -26,8 +31,8 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
+  /* display: flex; remove flex from body*/
+  /* place-items: center; we can have more control over layout in individual containers*/
   min-width: 320px;
   min-height: 100vh;
 }
@@ -54,6 +59,11 @@ button:hover {
 button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
+}
+/*Main culprit for breaking layout*/
+img {
+  display: block;
+  width: 100%;
 }
 
 @media (prefers-color-scheme: light) {


### PR DESCRIPTION
Changed some styling in App.css and added border-box to all elements to control overflow in index.css. Change some elements that had a view width set, can cause some weird element and content overflow from other containers. Changed them to a percentage to stay within the width of the parent. Added a media query to put flex on the `previewComponent` div at a larger screen size. Removed `text-align:center` on root div because it was causing some strange behavior with text. Targeted images so they wouldn't overflow their container based on their intrinsic size. Can't remember all other changes. Hopefully the changes work for you!